### PR TITLE
Adding tag fields.

### DIFF
--- a/roles/grafana-docker/tasks/main.yml
+++ b/roles/grafana-docker/tasks/main.yml
@@ -10,7 +10,7 @@
     register: grafana_config_ready
 
   - name: Ensure Grafana docker container
-    docker: 
+    docker:
       name: grafana
       image: "{{ grafana_docker_image }}"
       state: reloaded
@@ -28,7 +28,7 @@
     register: grafana_docker_container
 
   - name: Wait for Grafana API to start
-    wait_for: 
+    wait_for:
       port: "{{ grafana_console_port }}"
       timeout: 30
     when: grafana_docker_container|success
@@ -39,7 +39,7 @@
       url: "{{ grafana_url }}/api/datasources"
       force_basic_auth: yes
       user: "{{ grafana_admin_user }}"
-      password: "{{ grafana_admin_pwd }}"      
+      password: "{{ grafana_admin_pwd }}"
       return_content: yes
     until: grafana_datasources|success
     retries: 10
@@ -54,8 +54,8 @@
       force_basic_auth: yes
       user: "{{ grafana_admin_user }}"
       password: "{{ grafana_admin_pwd }}"
-      body_format: json      
-      body: "{{ lookup('template','datasource.json.j2') }}"
+      body_format: json
+      body: "{{ lookup('template','datasource.json.j2') | from_json }}"
       status_code: 200
     when: grafana_datasources.json[0] is not defined
 
@@ -66,11 +66,7 @@
       force_basic_auth: yes
       user: "{{ grafana_admin_user }}"
       password: "{{ grafana_admin_pwd }}"
-      body_format: json      
-      body: "{{ lookup('template','overview-dashboard.json.j2') }}"
+      body_format: json
+      body: "{{ lookup('template','overview-dashboard.json.j2') | from_json }}"
       status_code: 200
     when: grafana_datasources.json[0] is not defined
-
-
-
-

--- a/roles/riemann-docker/templates/riemann.config.j2
+++ b/roles/riemann-docker/templates/riemann.config.j2
@@ -25,7 +25,8 @@
                        :port {{ riemann_influxdb_port }}
                        :db "{{ riemann_influxdb_db }}"
                        :username "{{ riemann_influxdb_user }}"
-                       :password "{{ riemann_influxdb_pwd }}"}))))
+                       :password "{{ riemann_influxdb_pwd }}"
+                       :tag-fields #{:host :id :statementType}}))))
 
 ; Divide timestamp with 1000 if it is sent as ms to correctly handle ms precision
 (defn autoscale [ts]
@@ -33,6 +34,7 @@
 
 (let [index (index)]
   (streams
+
     (default :ttl 60
 
     (adjust [:time autoscale]


### PR DESCRIPTION
@nivancevic This is hardcoded PR which I do not like. Riemann is not tagging events to influx without `tag-fields` in configuration. In it you can specify fields which, if presented in event, will be tagged. In this PR it is hard coded and we can do something like extract tags if present and tag those which are present.

Do you know how to pull tags from event and tag those which are in array for influx.

Here is event with two tags:

```
#riemann.codec.Event{:host "192.168.34.20", :service "application_slow_query_final", :state "ok", :description nil, :metric 7, :tags ["type", "host"], :time 1470998556996, :ttl 30.0, :value "7", :type "SELECT", :count "2"}
```
