### PR TITLE
Fix osmetrics init.d script

### DIFF
--- a/roles/osmetrics/tasks/main.yml
+++ b/roles/osmetrics/tasks/main.yml
@@ -34,6 +34,8 @@
 
 - name: Install OS Metrics dependencies
   pip: requirements={{ osmetrics_install_dir }}/requirements.txt
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   when: download_osmetrics|changed
 
 - name: Ensure configuration directory

--- a/roles/osmetrics/templates/osmetrics.init.j2
+++ b/roles/osmetrics/templates/osmetrics.init.j2
@@ -104,9 +104,15 @@ case "$1" in
         condrestart|try-restart)
                 ;;
         status)
-                RETVAL=0
-                if [ -f $lockfile ] ; then
-                        RETVAL=2
+                if [ -f $PID_FILE ]; then
+                    PID=`cat $PID_FILE`
+                    if [ -z "`ps axf | grep -w ${PID} | grep -v grep`" ]; then
+                        RETVAL=1
+                    else
+                        RETVAL=0
+                    fi
+                else
+                    RETVAL=3
                 fi
                 ;;
         *)


### PR DESCRIPTION
OSmetrics init.d script cannot be run by Ansible, but can be run
manually. This issue was fixed by adding the appropriate status codes to
the `status` command. Besides that, the role was updated to allow root
account to use pip.
