### PR TITLE
Invert tagging invocation logic

### DIFF
--- a/projects/anomaly-detection-stack/README.md
+++ b/projects/anomaly-detection-stack/README.md
@@ -40,14 +40,14 @@ ansible-playbook -i projects/anomaly-detection-stack/inventory --private-key <pa
 To start the cluster, use the following command:
 
 ```
-ansible-playbook -i projects/anomaly-detection-stack/inventory --private-key <path to PEM file> projects/anomaly-detection-stack/layers/aws.yml --skip-tags "aws-stop,aws-setup"
+ansible-playbook -i projects/anomaly-detection-stack/inventory --private-key <path to PEM file> projects/anomaly-detection-stack/layers/aws.yml --tags aws-start
 ```
 
 Once you finish using the cluster, make sure you stop it by invoking the playbook as shown in the
 snipped below:
 
 ```
-ansible-playbook -i projects/anomaly-detection-stack/inventory --private-key <path to PEM file> projects/anomaly-detection-stack/layers/aws.yml --skip-tags "aws-start,aws-setup"
+ansible-playbook -i projects/anomaly-detection-stack/inventory --private-key <path to PEM file> projects/anomaly-detection-stack/layers/aws.yml --tags aws-stop
 ```
 
 [1]: https://aws.amazon.com/ec2/instance-types/

--- a/projects/anomaly-detection-stack/inventory/group_vars/cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/cassandra.yml
@@ -36,3 +36,7 @@ cassandra_diagnostics_binaries:
   - "{{ cassandra_diagnostics_url_core }}"
   - "{{ cassandra_diagnostics_url_connector }}"
   - "{{ cassandra_diagnostics_url_reporter_riemann }}"
+
+# OS metrics
+osmetrics_riemann_port: "{{ cassandra_diagnostics_riemann_port }}"
+osmetrics_riemann_host: "{{ monitoring_node }}"

--- a/projects/anomaly-detection-stack/layers/cassandra.yml
+++ b/projects/anomaly-detection-stack/layers/cassandra.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create Cassandra cluster
+- name: Cassandra cluster
   hosts: localhost
   connection: local
   roles:
@@ -16,13 +16,18 @@
 
 - name: Setup instances
   hosts: cassandra
+  gather_facts: False
+  tags: ['aws-setup', 'aws-start']
   remote_user: ubuntu
   become: yes
   become_method: sudo
+  pre_tasks:
+    - name: Gathering facts
+      setup:
   roles:
     - java
     - filebeat
     - cassandra
     - cassandra-metrics-reporter
     - cassandra-diagnostics
-  tags: ['aws-setup', 'aws-start']
+    - osmetrics

--- a/projects/anomaly-detection-stack/layers/cassandra.yml
+++ b/projects/anomaly-detection-stack/layers/cassandra.yml
@@ -25,5 +25,4 @@
     - cassandra
     - cassandra-metrics-reporter
     - cassandra-diagnostics
-  tags:
-    - aws-start
+  tags: ['aws-setup', 'aws-start']

--- a/projects/anomaly-detection-stack/layers/monitoring.yml
+++ b/projects/anomaly-detection-stack/layers/monitoring.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create monitoring node
+- name: Monitoring node
   hosts: localhost
   connection: local
   roles:
@@ -16,13 +16,17 @@
 
 - name: Setup instance
   hosts: monitoring
+  gather_facts: False
+  tags: ['aws-setup', 'aws-start']
   remote_user: ubuntu
   become: yes
   become_method: sudo
+  pre_tasks:
+    - name: Gathering facts
+      setup:
   roles:
     - docker-common
     - influxdb-docker
     - elk-docker
     - grafana-docker
     - riemann-docker
-  tags: ['aws-setup', 'aws-start']

--- a/projects/anomaly-detection-stack/layers/monitoring.yml
+++ b/projects/anomaly-detection-stack/layers/monitoring.yml
@@ -25,5 +25,4 @@
     - elk-docker
     - grafana-docker
     - riemann-docker
-  tags:
-    - aws-start
+  tags: ['aws-setup', 'aws-start']

--- a/roles/aws/tasks/main.yml
+++ b/roles/aws/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 - name: AWS | Launch instances
-  delegate_to: localhost
   vars:
-    launch_tags: "{{ ec2_tags|combine({'Group': ec2_group}) }}"
+    launch_tags: '{{ ec2_tags|combine({"Group": ec2_group}) }}'
   ec2:
     region: '{{ ec2_region }}'
     image: '{{ ec2_image_id }}'
@@ -16,47 +15,56 @@
   tags: 'aws-setup'
 
 - name: AWS | Retrieve instances info
-  delegate_to: localhost
   ec2_remote_facts:
     region: '{{ ec2_region }}'
     filters:
       'tag:Group': '{{ ec2_group }}'
-  register: ec2
+  register: ec2_info
+  tags: ['aws-setup', 'aws-start', 'aws-stop']
+
+- name: AWS | Collect instance identifiers
+  set_fact:
+    instance_ids: '{{ ec2_info.instances | map(attribute="id") | list }}'
+  tags: ['aws-setup', 'aws-start', 'aws-stop']
+
+- name: AWS | Start instances
+  ec2:
+    instance_ids: '{{ instance_ids }}'
+    region: '{{ ec2_region }}'
+    state: running
+    wait: true
+  tags: 'aws-start'
+
+- name: AWS | Refresh instances info to acquire public DNS
+  ec2_remote_facts:
+    region: '{{ ec2_region }}'
+    filters:
+      'tag:Group': '{{ ec2_group }}'
+  register: ec2_info
+  tags: 'aws-start'
 
 - name: AWS | Build group
-  delegate_to: localhost
   add_host:
     hostname: '{{ item.public_dns_name }}'
     groupname: '{{ ec2_group }}'
     private_ip: '{{ item.private_ip_address }}'
-  with_items: '{{ ec2.instances }}'
-
-- name: AWS | Start instances
-  delegate_to: localhost
-  ec2:
-    instance_ids: '{{ item.id }}'
-    region: '{{ ec2_region }}'
-    state: running
-    wait: true
-  with_items: '{{ ec2.instances }}'
-  tags: 'aws-start'
+  with_items: '{{ ec2_info.instances }}'
+  tags: ['aws-setup', 'aws-start', 'aws-stop']
 
 - name: AWS | Check SSH connections
-  delegate_to: localhost
   wait_for:
     host: '{{ item.public_dns_name }}'
     port: 22
+    delay: 15
     timeout: 120
     state: started
-  with_items: '{{ ec2.instances }}'
-  tags: 'aws-start'
+  with_items: '{{ ec2_info.instances }}'
+  tags: ['aws-setup', 'aws-start']
 
 - name: AWS | Stop instances
-  delegate_to: localhost
   ec2:
-    instance_ids: '{{ item.id }}'
+    instance_ids: '{{ instance_ids }}'
     region: '{{ ec2_region }}'
     state: stopped
     wait: true
-  with_items: '{{ ec2.instances }}'
   tags: 'aws-stop'

--- a/roles/osmetrics/tasks/main.yml
+++ b/roles/osmetrics/tasks/main.yml
@@ -1,8 +1,13 @@
 - name: Ensure unzip tool
   package: name=unzip state=present
 
-- name: Ensure phyton binding
+- name: Ensure python binding
   package: name=libselinux-python state=present
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+
+- name: Ensure python binding
+  package: name=python-selinux state=present
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Check for pip
   stat: path=/usr/bin/pip
@@ -47,6 +52,12 @@
 - name: Install OS Metrics init script
   template: src=osmetrics.init.j2 dest=/etc/rc.d/init.d/osmetrics mode=755
   register: init_script
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+
+- name: Install OS Metrics init script
+  template: src=osmetrics.init.j2 dest=/etc/init.d/osmetrics mode=755
+  register: init_script
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Restart OS Metrics service
   service: name=osmetrics enabled=yes state=restarted


### PR DESCRIPTION
Using tags, instead of skip-tags to invoke the appropriate tasks. 

Fixed the SSH timeout error while starting the existing instances. The problem was caused by the fact that stopped instances does not have a public DNS name. It is solved by acquiring the remote facts immediately after starting them.
