### PR TITLE
AWS volumes setup

### DIFF
--- a/projects/anomaly-detection-stack/inventory/group_vars/all.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/all.yml
@@ -1,2 +1,3 @@
 ---
 java_version: java8jre
+monitoring_node_private: '{{ hostvars[groups["smart-monitoring"][0]]["private_ip"] }}'

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
@@ -21,7 +21,7 @@ monitoring_node: '{{ hostvars[groups["smart-monitoring"][0]]["private_ip"] }}'
 filebeat_elasticsearch_hosts: "'{{ monitoring_node }}:9200'"
 
 # Diagnostics
-cassandra_diagnostics_version: "1.1.2"
+cassandra_diagnostics_version: "1.1.1"
 cassandra_diagnostics_connector_version: "21"
 cassandra_diagnostics_version_file: "/opt/cassandra-diagnostics.version"
 cassandra_diagnostics_configuration_file: ../../anomaly-detection-stack/templates/cassandra-diagnostics.yml.j2

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
@@ -17,8 +17,7 @@ cassandra_env_max_heap_size: 512M
 cassandra_env_heap_newsize: 100M
 
 # Filebeat
-monitoring_node: '{{ hostvars[groups["smart-monitoring"][0]]["private_ip"] }}'
-filebeat_elasticsearch_hosts: "'{{ monitoring_node }}:9200'"
+filebeat_elasticsearch_hosts: "'{{ monitoring_node_private }}:9200'"
 
 # Diagnostics
 cassandra_diagnostics_version: "1.1.1"
@@ -27,10 +26,10 @@ cassandra_diagnostics_version_file: "/opt/cassandra-diagnostics.version"
 cassandra_diagnostics_configuration_file: ../../anomaly-detection-stack/templates/cassandra-diagnostics.yml.j2
 cassandra_diagnostics_target_dir: "/usr/share/cassandra/lib/"
 
-cassandra_diagnostics_riemann_host: "{{ monitoring_node }}"
+cassandra_diagnostics_riemann_host: "{{ monitoring_node_private }}"
 cassandra_diagnostics_riemann_port: 5555
 
-riemann_server_address: "{{ monitoring_node }}"
+riemann_server_address: "{{ monitoring_node_private }}"
 
 cassandra_diagnostics_binaries:
   - "{{ cassandra_diagnostics_url_core }}"
@@ -42,4 +41,4 @@ cassandra_diagnostics_jmx_port: 7199
 
 # OS metrics
 osmetrics_riemann_port: "{{ cassandra_diagnostics_riemann_port }}"
-osmetrics_riemann_host: "{{ monitoring_node }}"
+osmetrics_riemann_host: "{{ monitoring_node_private }}"

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-monitoring.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-monitoring.yml
@@ -1,3 +1,6 @@
+playbook_tasks: "{{ inventory_dir }}/../tasks"
+data_volume: "/mnt/data"
+
 monitor_user: "admin"
 monitor_pwd: "secret"
 monitor_grafana_port: "3000"
@@ -20,10 +23,8 @@ grafana_influxdb_db: "{{ monitor_influxdb_db }}"
 grafana_influxdb_user: "{{ monitor_user }}"
 grafana_influxdb_pwd: "{{ monitor_pwd }}"
 grafana_elasticsearch_db: "{{ monitor_elasticsearch_db }}"
-grafana_influxdb_url: "http://{{ inventory_hostname }}:{{ monitor_influxdb_port }}"
-grafana_elasticsearch_url: "http://{{ inventory_hostname }}:{{ monitor_elasticsearch_port }}"
-
-data_volume: "/mnt/data"
+grafana_influxdb_url: "http://{{ monitoring_node_private }}:{{ monitor_influxdb_port }}"
+grafana_elasticsearch_url: "http://{{ monitoring_node_private }}:{{ monitor_elasticsearch_port }}"
 
 influxdb_version: "0.13"
 influxdb_admin_user: "{{ monitor_user }}"

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-monitoring.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-monitoring.yml
@@ -23,17 +23,21 @@ grafana_elasticsearch_db: "{{ monitor_elasticsearch_db }}"
 grafana_influxdb_url: "http://{{ inventory_hostname }}:{{ monitor_influxdb_port }}"
 grafana_elasticsearch_url: "http://{{ inventory_hostname }}:{{ monitor_elasticsearch_port }}"
 
+data_volume: "/mnt/data"
+
 influxdb_version: "0.13"
 influxdb_admin_user: "{{ monitor_user }}"
 influxdb_admin_pwd: "{{ monitor_pwd }}"
 influxdb_pre_created_db: "{{ monitor_influxdb_db }}"
 influxdb_console_port: "{{ monitor_influxdb_console_port }}"
 influxdb_api_port: "{{ monitor_influxdb_port }}"
+influxdb_data_path: "{{ data_volume }}/influxdb"
 
 elk_kibana_port: "{{ monitor_kibana_port }}"
 elk_elasticsearch_port: "{{ monitor_elasticsearch_port }}"
 elk_logstash_beats_port: "{{ monitor_logstash_beats_port }}"
 elk_logstash_lumberjack_port: "{{ monitor_logstash_lumberjack_port }}"
+elk_elasticsearch_data_path: "{{ data_volume }}/elasticsearch"
 
 riemann_influxdb_version: "0.9"
 riemann_tcp_port: "{{ monitor_riemann_port }}"

--- a/projects/anomaly-detection-stack/layers/cassandra.yml
+++ b/projects/anomaly-detection-stack/layers/cassandra.yml
@@ -29,4 +29,5 @@
     - filebeat
     - cassandra
     - cassandra-diagnostics
+    - cassandra-metrics-reporter
     - osmetrics

--- a/projects/anomaly-detection-stack/layers/cassandra.yml
+++ b/projects/anomaly-detection-stack/layers/cassandra.yml
@@ -4,14 +4,14 @@
   connection: local
   roles:
     - role: aws
-      ec2_tags:
-        Name: "smart-cassandra"
-      ec2_region: eu-central-1
-      ec2_image_id: ami-26c43149
       ec2_key_name: "eu-smartcat"
       ec2_security_group: "anomaly-stack"
+      ec2_image_id: ami-26c43149
       ec2_instance_type: t2.micro
+      ec2_region: eu-central-1
       ec2_count: 3
+      ec2_tags:
+        Name: "smart-cassandra"
       ec2_group: smart-cassandra
 
 - name: Setup instances

--- a/projects/anomaly-detection-stack/layers/monitoring.yml
+++ b/projects/anomaly-detection-stack/layers/monitoring.yml
@@ -35,7 +35,6 @@
       tags: ['aws-setup', 'aws-start']
     - name: Run filesystem setup
       include: "{{ playbook_tasks }}/monitoring-os-setup.yml"
-      when: tags is defined
       tags: ['aws-setup']
   roles:
     - { role: docker-common, tags: ['aws-setup', 'aws-start'] }

--- a/projects/anomaly-detection-stack/layers/monitoring.yml
+++ b/projects/anomaly-detection-stack/layers/monitoring.yml
@@ -4,29 +4,42 @@
   connection: local
   roles:
     - role: aws
-      ec2_tags:
-        Name: "smart-monitoring"
-      ec2_region: eu-central-1
-      ec2_image_id: ami-26c43149
       ec2_key_name: "eu-smartcat"
       ec2_security_group: "anomaly-stack"
+      ec2_image_id: ami-26c43149
       ec2_instance_type: m4.xlarge
+      ec2_region: eu-central-1
       ec2_count: 1
+      ec2_volumes:
+        - device_name: /dev/sda1
+          volume_type: gp2
+          volume_size: 30
+          delete_on_termination: true
+        - device_name: /dev/sdh
+          volume_type: gp2
+          volume_size: 100
+          delete_on_termination: true
+      ec2_tags:
+        Name: "smart-monitoring"
       ec2_group: smart-monitoring
 
 - name: Setup instance
   hosts: smart-monitoring
   gather_facts: False
-  tags: ['aws-setup', 'aws-start']
   remote_user: ubuntu
   become: yes
   become_method: sudo
   pre_tasks:
     - name: Gathering facts
       setup:
+      tags: ['aws-setup', 'aws-start']
+    - name: Run filesystem setup
+      include: "{{ playbook_tasks }}/monitoring-os-setup.yml"
+      when: tags is defined
+      tags: ['aws-setup']
   roles:
-    - docker-common
-    - influxdb-docker
-    - elk-docker
-    - grafana-docker
-    - riemann-docker
+    - { role: docker-common, tags: ['aws-setup', 'aws-start'] }
+    - { role: influxdb-docker, tags: ['aws-setup', 'aws-start'] }
+    - { role: elk-docker, tags: ['aws-setup', 'aws-start'] }
+    - { role: grafana-docker, tags: ['aws-setup', 'aws-start'] }
+    - { role: riemann-docker, tags: ['aws-setup', 'aws-start'] }

--- a/projects/anomaly-detection-stack/tasks/monitoring-os-setup.yml
+++ b/projects/anomaly-detection-stack/tasks/monitoring-os-setup.yml
@@ -1,11 +1,14 @@
+- name: Install dependencies
+  package: name=xfsprogs state=present
+
 - name: Create data fs
   command: mkfs.xfs -s size=4096 /dev/xvdh
 
 - name: Create mount folders
   file: path={{ item }} state=directory mode=0755
   with_items:
-    - {{ elk_elasticsearch_data_path }}
-    - {{ influxdb_data_path }}
+    - '{{ elk_elasticsearch_data_path }}'
+    - '{{ influxdb_data_path }}'
 
 - name: Update fstab
   lineinfile:

--- a/projects/anomaly-detection-stack/tasks/monitoring-os-setup.yml
+++ b/projects/anomaly-detection-stack/tasks/monitoring-os-setup.yml
@@ -1,0 +1,17 @@
+- name: Create data fs
+  command: mkfs.xfs -s size=4096 /dev/xvdh
+
+- name: Create mount folders
+  file: path={{ item }} state=directory mode=0755
+  with_items:
+    - {{ elk_elasticsearch_data_path }}
+    - {{ influxdb_data_path }}
+
+- name: Update fstab
+  lineinfile:
+    dest: /etc/fstab
+    state: present
+    line: '/dev/xvdh       {{ data_volume }}        xfs     defaults,noatime        0       0'
+
+- name: Run mount all
+  command: mount -a

--- a/projects/anomaly-detection-stack/templates/cassandra-diagnostics.yml.j2
+++ b/projects/anomaly-detection-stack/templates/cassandra-diagnostics.yml.j2
@@ -17,29 +17,6 @@ modules:
     reporters:
       - io.smartcat.cassandra.diagnostics.reporter.LogReporter
       - io.smartcat.cassandra.diagnostics.reporter.RiemannReporter
-  - module: io.smartcat.cassandra.diagnostics.module.metrics.MetricsModule
-    options:
-      period: 1
-      timeunit: SECONDS
-      jmxHost: '{{ cassandra_diagnostics_jmx_host }}'
-      jmxPort: '{{ cassandra_diagnostics_jmx_port }}'
-      metricsPatterns:
-        - "^org.apache.cassandra.metrics.Cache.+"
-        - "^org.apache.cassandra.metrics.ClientRequest.+"
-        - "^org.apache.cassandra.metrics.CommitLog.+"
-        - "^org.apache.cassandra.metrics.Compaction.+"
-        - "^org.apache.cassandra.metrics.ColumnFamily.PendingTasks"
-        - "^org.apache.cassandra.metrics.ColumnFamily.ReadLatency"
-        - "^org.apache.cassandra.metrics.ColumnFamily.WriteLatency"
-        - "^org.apache.cassandra.metrics.ColumnFamily.ReadTotalLatency"
-        - "^org.apache.cassandra.metrics.ColumnFamily.WriteTotalLatency"
-        - "^org.apache.cassandra.metrics.DroppedMetrics.+"
-        - "^org.apache.cassandra.metrics.ReadRepair.+"
-        - "^org.apache.cassandra.metrics.Storage.+"
-        - "^org.apache.cassandra.metrics.ThreadPools.+"
-    reporters:
-      - io.smartcat.cassandra.diagnostics.reporter.LogReporter
-      - io.smartcat.cassandra.diagnostics.reporter.RiemannReporter
   - module: io.smartcat.cassandra.diagnostics.module.slowquery.SlowQueryModule
     measurement: queryReport
     options:

--- a/roles/aws/defaults/main.yml
+++ b/roles/aws/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
-ec2_tags: {}
-ec2_region: eu-central-1
-ec2_image_id: ami-26c43149
 ec2_key_name: dummy-key
-ec2_security_group: dummy-group
-ec2_instance_type: t2.micro
-ec2_count: 1
 ec2_group: dummy-group
+ec2_image_id: ami-26c43149
+ec2_instance_type: t2.micro
+ec2_region: eu-central-1
+ec2_volumes: null
+ec2_tags: {}
+ec2_security_group: dummy-group
+ec2_count: 1

--- a/roles/aws/tasks/main.yml
+++ b/roles/aws/tasks/main.yml
@@ -3,13 +3,14 @@
   vars:
     launch_tags: '{{ ec2_tags|combine({"Group": ec2_group}) }}'
   ec2:
-    region: '{{ ec2_region }}'
-    image: '{{ ec2_image_id }}'
     key_name: '{{ ec2_key_name }}'
     group: '{{ ec2_security_group }}'
+    image: '{{ ec2_image_id }}'
     instance_type: '{{ ec2_instance_type }}'
-    instance_tags: '{{ launch_tags }}'
+    region: '{{ ec2_region }}'
+    volumes: '{{ ec2_volumes }}'
     count_tag: '{{ launch_tags }}'
+    instance_tags: '{{ launch_tags }}'
     exact_count: '{{ ec2_count }}'
     wait: true
   tags: 'aws-setup'

--- a/roles/filebeat/tasks/main.yml
+++ b/roles/filebeat/tasks/main.yml
@@ -18,5 +18,5 @@
 - name: Copy filebeat configuration
   template: src=filebeat.yml.j2 dest=/etc/filebeat/filebeat.yml mode=0755
 
-- name: Set filebeat srevice
+- name: Set filebeat service
   service: name=filebeat enabled=yes state=restarted

--- a/roles/grafana-docker/tasks/main.yml
+++ b/roles/grafana-docker/tasks/main.yml
@@ -178,7 +178,7 @@
       user: "{{ grafana_admin_user }}"
       password: "{{ grafana_admin_pwd }}"
       body_format: json
-      body: "{{ lookup('template','cluster-cassandra-os-stats-dashboard.json.j2') | from_json }}"
+      body: "{{ lookup('template','cluster-os-stats-dashboard.json.j2') | from_json }}"
       status_code: 200
     when: grafana_cluster_os_stats_dashboard.json.dashboard is not defined
 
@@ -201,7 +201,7 @@
       user: "{{ grafana_admin_user }}"
       password: "{{ grafana_admin_pwd }}"
       body_format: json
-      body: "{{ lookup('template','cluster-cassandra-disk-stats-dashboard.json.j2') | from_json }}"
+      body: "{{ lookup('template','cluster-disk-stats-dashboard.json.j2') | from_json }}"
       status_code: 200
     when: grafana_cluster_disk_stats_dashboard.json.dashboard is not defined
 
@@ -224,6 +224,6 @@
       user: "{{ grafana_admin_user }}"
       password: "{{ grafana_admin_pwd }}"
       body_format: json
-      body: "{{ lookup('template','cluster-cassandra-network-stats-dashboard.json.j2') | from_json }}"
+      body: "{{ lookup('template','cluster-network-stats-dashboard.json.j2') | from_json }}"
       status_code: 200
     when: grafana_cluster_network_stats_dashboard.json.dashboard is not defined

--- a/roles/grafana-docker/templates/cluster-disk-stats-dashboard.json.j2
+++ b/roles/grafana-docker/templates/cluster-disk-stats-dashboard.json.j2
@@ -717,4 +717,5 @@
     "version": 1,
     "links": [],
     "gnetId": null
+  }
 }

--- a/roles/grafana-docker/templates/cluster-network-stats-dashboard.json.j2
+++ b/roles/grafana-docker/templates/cluster-network-stats-dashboard.json.j2
@@ -1064,4 +1064,5 @@
     "version": 2,
     "links": [],
     "gnetId": null
+  }
 }

--- a/roles/grafana-docker/templates/cluster-os-stats-dashboard.json.j2
+++ b/roles/grafana-docker/templates/cluster-os-stats-dashboard.json.j2
@@ -481,4 +481,5 @@
     "version": 2,
     "links": [],
     "gnetId": null
+  }
 }

--- a/roles/grafana-docker/templates/influx_datasource.json.j2
+++ b/roles/grafana-docker/templates/influx_datasource.json.j2
@@ -1,1 +1,1 @@
-{"name":"InfluxDB","type":"influxdb","url":"{{ grafana_influxdb_url }}","access":"direct","isDefault":true,"basicAuth":false,"database":"{{ grafana_influxdb_db }}","user":"{{ grafana_influxdb_user }}","password":"{{ grafana_influxdb_pwd }}"}
+{"name":"InfluxDB","type":"influxdb","url":"{{ grafana_influxdb_url }}","access":"proxy","isDefault":true,"basicAuth":false,"database":"{{ grafana_influxdb_db }}","user":"{{ grafana_influxdb_user }}","password":"{{ grafana_influxdb_pwd }}"}


### PR DESCRIPTION
Monitoring instance is configured with 2 volumes: 30GB for system, and 100GB for elasticsearch and influx data.

PR includes the following fixes:
- grafana sources are set to private IP addresses
- influx data source access is changes to proxy (grafana backend will proxy the request)
