### PR TITLE
Add the load generator node

### DIFF
--- a/projects/anomaly-detection-stack/inventory/group_vars/all.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/all.yml
@@ -1,3 +1,4 @@
 ---
 java_version: java8jre
+cassandra_version: 2.1.15
 monitoring_node_private: '{{ hostvars[groups["smart-monitoring"][0]]["private_ip"] }}'

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
@@ -1,7 +1,5 @@
 ---
-# Cassandra
 cassandra_dsc_version: dsc21
-cassandra_version: 2.1.15
 
 cassandra_seed_0: '{{ hostvars[groups["smart-cassandra"][0]]["private_ip"] }}'
 cassandra_seed_1: '{{ hostvars[groups["smart-cassandra"][1]]["private_ip"] }}'

--- a/projects/anomaly-detection-stack/layers/aws.yml
+++ b/projects/anomaly-detection-stack/layers/aws.yml
@@ -1,2 +1,3 @@
 - include: monitoring.yml
 - include: cassandra.yml
+- include: loadgen.yml

--- a/projects/anomaly-detection-stack/layers/loadgen.yml
+++ b/projects/anomaly-detection-stack/layers/loadgen.yml
@@ -1,0 +1,29 @@
+---
+- name: Load generator node
+  hosts: localhost
+  connection: local
+  roles:
+    - role: aws
+      ec2_key_name: "eu-smartcat"
+      ec2_security_group: "anomaly-stack"
+      ec2_image_id: ami-26c43149
+      ec2_instance_type: t2.micro
+      ec2_region: eu-central-1
+      ec2_count: 1
+      ec2_tags:
+        Name: "smart-load-gen"
+      ec2_group: smart-load-gen
+
+- name: Setup instance
+  hosts: smart-load-gen
+  gather_facts: False
+  tags: ['aws-setup', 'aws-start']
+  remote_user: ubuntu
+  become: yes
+  become_method: sudo
+  pre_tasks:
+    - name: Gathering facts
+      setup:
+  roles:
+    - java
+    - cassandra-tools

--- a/roles/cassandra-tools/defaults/main.yml
+++ b/roles/cassandra-tools/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+cassandra_version: 3.0.8

--- a/roles/cassandra-tools/tasks/main.yml
+++ b/roles/cassandra-tools/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Cassandra Tools | Add datastax APT repository keys
+  apt_key: url=http://debian.datastax.com/debian/repo_key state=present
+
+- name: Cassandra Tools | Add datastax APT repository
+  apt_repository: repo="deb http://debian.datastax.com/community stable main" state=present
+
+- name: Cassandra Tools | Install package
+  apt: name={{ item }} state=present update-cache=yes force=yes
+  with_items:
+    - "cassandra={{ cassandra_version }}"
+
+- name: Cassandra Tools | Prevent Cassandra from running
+  service: name=cassandra state=stopped


### PR DESCRIPTION
At the moment, this node will contain only the cassandra tools that are
available upon installation.
