### PR TITLE
Upgrade the load generator node to t2.large

### DIFF
--- a/projects/anomaly-detection-stack/layers/loadgen.yml
+++ b/projects/anomaly-detection-stack/layers/loadgen.yml
@@ -7,7 +7,7 @@
       ec2_key_name: "eu-smartcat"
       ec2_security_group: "anomaly-stack"
       ec2_image_id: ami-26c43149
-      ec2_instance_type: t2.micro
+      ec2_instance_type: t2.large
       ec2_region: eu-central-1
       ec2_count: 1
       ec2_tags:

--- a/roles/cassandra-tools/tasks/main.yml
+++ b/roles/cassandra-tools/tasks/main.yml
@@ -1,14 +1,6 @@
 ---
-- name: Cassandra Tools | Add datastax APT repository keys
-  apt_key: url=http://debian.datastax.com/debian/repo_key state=present
-
-- name: Cassandra Tools | Add datastax APT repository
-  apt_repository: repo="deb http://debian.datastax.com/community stable main" state=present
-
-- name: Cassandra Tools | Install package
-  apt: name={{ item }} state=present update-cache=yes force=yes
-  with_items:
-    - "cassandra={{ cassandra_version }}"
-
-- name: Cassandra Tools | Prevent Cassandra from running
-  service: name=cassandra state=stopped
+- name: Load generator | Download cassandra tools
+  unarchive:
+    src: "http://downloads.datastax.com/community/dsc-cassandra-{{ cassandra_version }}-bin.tar.gz"
+    dest: "/opt"
+    copy: no


### PR DESCRIPTION
Due to low memory, t2.micro could not perform the cassandra-stress test. Besides upgrading the node, cassandra-tools role is rewritten to use tarball cassandra instead of a distribution package.
