### PR TITLE
Telegraf, cassandra 3.0.8

### DIFF
--- a/projects/anomaly-detection-stack/inventory/group_vars/all.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/all.yml
@@ -1,4 +1,4 @@
 ---
 java_version: java8jre
-cassandra_version: 2.1.15
+cassandra_version: 3.0.8
 monitoring_node_private: '{{ hostvars[groups["smart-monitoring"][0]]["private_ip"] }}'

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
@@ -38,9 +38,11 @@ cassandra_diagnostics_binaries:
 cassandra_diagnostics_jmx_host: 127.0.0.1
 cassandra_diagnostics_jmx_port: 7199
 
-# OS metrics
+# Telegraf
 telegraf_version: "1.0.1"
 telegraf_collection_interval: 10s
+telegraf_install_url_deb: "https://dl.influxdata.com/telegraf/releases/telegraf_{{ telegraf_version }}_amd64.deb"
+
 telegraf_influxdb_address: "http://{{ monitoring_node_private }}:8086"
 telegraf_influxdb_database: "metric"
 telegraf_influxdb_retention_policy: ""

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
@@ -1,5 +1,5 @@
 ---
-cassandra_dsc_version: dsc21
+cassandra_dsc_version: dsc30
 
 cassandra_seed_0: '{{ hostvars[groups["smart-cassandra"][0]]["private_ip"] }}'
 cassandra_seed_1: '{{ hostvars[groups["smart-cassandra"][1]]["private_ip"] }}'
@@ -11,6 +11,7 @@ cluster_name: App Cluster
 
 cassandra_user: "root"
 cassandra_configuration_dir: "/etc/cassandra/"
+cassandra_lib_location: "/usr/share/cassandra/lib/"
 cassandra_env_max_heap_size: 2G
 cassandra_env_heap_newsize: 300M
 
@@ -19,10 +20,10 @@ filebeat_elasticsearch_hosts: "'{{ monitoring_node_private }}:9200'"
 
 # Diagnostics
 cassandra_diagnostics_version: "1.2.0"
-cassandra_diagnostics_connector_version: "21"
+cassandra_diagnostics_connector_version: "30"
 cassandra_diagnostics_version_file: "/opt/cassandra-diagnostics.version"
 cassandra_diagnostics_configuration_file: ../../anomaly-detection-stack/templates/cassandra-diagnostics.yml.j2
-cassandra_diagnostics_target_dir: "/usr/share/cassandra/lib/"
+cassandra_diagnostics_target_dir: "{{ cassandra_lib_location }}"
 
 cassandra_diagnostics_riemann_host: "{{ monitoring_node_private }}"
 cassandra_diagnostics_riemann_port: 5555

--- a/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
+++ b/projects/anomaly-detection-stack/inventory/group_vars/smart-cassandra.yml
@@ -19,7 +19,7 @@ cassandra_env_heap_newsize: 300M
 filebeat_elasticsearch_hosts: "'{{ monitoring_node_private }}:9200'"
 
 # Diagnostics
-cassandra_diagnostics_version: "1.2.0"
+cassandra_diagnostics_version: "1.2.1"
 cassandra_diagnostics_connector_version: "30"
 cassandra_diagnostics_version_file: "/opt/cassandra-diagnostics.version"
 cassandra_diagnostics_configuration_file: ../../anomaly-detection-stack/templates/cassandra-diagnostics.yml.j2

--- a/roles/cassandra/defaults/main.yml
+++ b/roles/cassandra/defaults/main.yml
@@ -15,6 +15,7 @@ cassandra_jmx_port: 7199
 cassandra_system_user: cassandra
 cluster_name: Test Cluster
 cassandra_configuration_dir: "/etc/cassandra/"
+cassandra_lib_location: "/usr/share/cassandra/lib/"
 
 cassandra_env_max_heap_size: 1G
 cassandra_env_heap_newsize: 100M

--- a/roles/telegraf-agent/defaults/main.yml
+++ b/roles/telegraf-agent/defaults/main.yml
@@ -1,5 +1,7 @@
 telegraf_version: "1.0.1"
 telegraf_collection_interval: 10s
+telegraf_install_url_deb: "https://dl.influxdata.com/telegraf/releases/telegraf_{{ telegraf_version }}_amd64.deb"
+telegraf_install_url_rpm: "https://dl.influxdata.com/telegraf/releases/telegraf-{{ telegraf_version }}.x86_64.rpm"
 
 telegraf_influxdb_address: "http://influxdb:8086"
 telegraf_influxdb_database: "metric"

--- a/roles/telegraf-agent/tasks/main.yml
+++ b/roles/telegraf-agent/tasks/main.yml
@@ -1,13 +1,30 @@
 - name: Install yum package
   yum:
-    name: "https://dl.influxdata.com/telegraf/releases/telegraf-{{ telegraf_version }}.x86_64.rpm"
+    name: "{{ telegraf_install_url_rpm }}"
     state: present
   when: ansible_os_family == "RedHat"
   register: yum_installed
 
-- name: Install apt package
+- name: Install any necessary dependencies [Debian/Ubuntu]
   apt:
-    deb: "https://dl.influxdata.com/telegraf/releases/telegraf_{{ telegraf_version }}_amd64.deb"
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  with_items:
+    - python-httplib2
+    - python-apt
+    - curl
+    - apt-transport-https
+  when: ansible_os_family == "Debian"
+
+- name: Download Telegraf package via URL [Debian/Ubuntu]
+  command: curl -o /tmp/telegraf.deb {{ telegraf_install_url_deb }}
+  when: ansible_os_family == "Debian"
+
+- name: Install downloaded Telegraf package [Debian/Ubuntu]
+  apt:
+    deb: /tmp/telegraf.deb
     state: present
   when: ansible_os_family == "Debian"
   register: apt_installed


### PR DESCRIPTION
New features:
- the stack now uses cassandra 3.0.8
- osmetrics is replaced with telegraf

Fixes:
- telegraf-agent role for deb-based systems
